### PR TITLE
THE-8: Harden Shopify extraction and popup reliability

### DIFF
--- a/src/assets/styles/components/_buttons.scss
+++ b/src/assets/styles/components/_buttons.scss
@@ -17,4 +17,11 @@
   &:hover {
     background-color: variables.$primary-600;
   }
+
+  &:disabled {
+    background-color: variables.$neutral-600;
+    box-shadow: none;
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
 }

--- a/src/assets/styles/components/_buttons.scss
+++ b/src/assets/styles/components/_buttons.scss
@@ -1,4 +1,4 @@
-@use "../variables";
+@use '../variables';
 
 .button {
   font-family: inherit;

--- a/src/containers/StorefrontComponent/StorefrontComponent.jsx
+++ b/src/containers/StorefrontComponent/StorefrontComponent.jsx
@@ -8,20 +8,29 @@ import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 const StorefrontComponent = ({ state }) => {
-  // console.log('State', state);
-  const getPreviewURL = () => {
-    if (state.storefrontInformation.location) {
-        const url = new URL(state.storefrontInformation.location);
+  const themeId = state?.storefrontInformation?.theme?.id;
+  const shopDomain = state?.storefrontInformation?.shop;
 
-        return url.search ? `${url.href}&preview_theme_id=${state.storefrontInformation.theme.id}` : `${url.href}?preview_theme_id=${state.storefrontInformation.theme.id}`;
+  const getPreviewURL = () => {
+    if (!shopDomain || !themeId) {
+      return null;
     }
-  }
+
+    const previewUrl = new URL(`https://${shopDomain}`);
+    previewUrl.searchParams.set('preview_theme_id', themeId);
+
+    return previewUrl.toString();
+  };
 
   const getEditorURL = () => {
-    return `https://${state.urls.adminBase}/themes/${state.storefrontInformation.theme.id}/editor`;
-  }
+    if (!themeId || !state?.urls?.adminBase) {
+      return null;
+    }
 
-  const launchToast = (message) => {
+    return `https://${state.urls.adminBase}/themes/${themeId}/editor`;
+  };
+
+  const launchSuccessToast = (message) => {
     toast.success(`${message}`, {
       position: "bottom-center",
       autoClose: 1000,
@@ -30,29 +39,68 @@ const StorefrontComponent = ({ state }) => {
       pauseOnHover: false,
       draggable: false
     });
-  }
+  };
+
+  const launchErrorToast = (message) => {
+    toast.error(`${message}`, {
+      position: "bottom-center",
+      autoClose: 1500,
+      hideProgressBar: true,
+      closeOnClick: true,
+      pauseOnHover: false,
+      draggable: false
+    });
+  };
 
   const copyPreviewURL = () => {
-    copyToClipboard(getPreviewURL(), 'Preview URL copied');
-  }
+    const previewUrl = getPreviewURL();
+
+    if (!previewUrl) {
+      launchErrorToast('Preview URL unavailable');
+      return;
+    }
+
+    copyToClipboard(previewUrl, 'Preview URL copied');
+  };
 
   const copyPreviewAndEditorURL = () => {
-    copyToClipboard(`Theme name: ${state.storefrontInformation.theme.name}\n\nPreview: ${getPreviewURL()}\nEditor: ${getEditorURL()}`, 'Preview & Editor URL copied');
-  }
+    const previewUrl = getPreviewURL();
+    const editorUrl = getEditorURL();
+
+    if (!previewUrl || !editorUrl) {
+      launchErrorToast('Preview or Editor URL unavailable');
+      return;
+    }
+
+    copyToClipboard(`Theme name: ${state.storefrontInformation.theme.name}\n\nPreview: ${previewUrl}\nEditor: ${editorUrl}`, 'Preview & Editor URL copied');
+  };
 
   const copyThemeId = () => {
-    copyToClipboard(state.storefrontInformation.theme.id, 'Theme ID copied');
-  }
+    if (!themeId) {
+      launchErrorToast('Theme ID unavailable');
+      return;
+    }
+
+    copyToClipboard(themeId, 'Theme ID copied');
+  };
 
   const copyToClipboard = async (text, toastText) => {
+    if (!text) {
+      launchErrorToast('Nothing to copy');
+      return;
+    }
+
     try {
       await navigator.clipboard.writeText(text);
-      launchToast(toastText);
+      launchSuccessToast(toastText);
     } catch (err) {
       console.error('Failed to copy:', err);
-      launchToast('Failed to copy to clipboard', 'error'); // Assuming launchToast can handle error messages
+      launchErrorToast('Failed to copy to clipboard');
     }
-  }
+  };
+
+  const previewUrlAvailable = Boolean(getPreviewURL());
+  const editorUrlAvailable = Boolean(getEditorURL());
 
 
   return (
@@ -82,10 +130,10 @@ const StorefrontComponent = ({ state }) => {
                 <button className='button' title="Copy theme ID" onClick={() => copyThemeId()}>
                   Theme ID
                 </button>
-                <button className='button' title="Copy preview URL" onClick={() => copyPreviewURL()}>
+                <button className='button' title="Copy preview URL" onClick={() => copyPreviewURL()} disabled={!previewUrlAvailable}>
                   Preview URL
                 </button>
-                <button className='button' title="Copy preview &amp; editor URLs" onClick={() => copyPreviewAndEditorURL()}>
+                <button className='button' title="Copy preview &amp; editor URLs" onClick={() => copyPreviewAndEditorURL()} disabled={!previewUrlAvailable || !editorUrlAvailable}>
                   Preview &amp; Editor URL
                 </button>
               </div>

--- a/src/containers/StorefrontComponent/StorefrontComponent.jsx
+++ b/src/containers/StorefrontComponent/StorefrontComponent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Icon from '../Icon/Icon';
-import "./StorefrontComponent.scss";
+import './StorefrontComponent.scss';
 import '../../pages/Popup/Popup.scss';
 import '@fontsource-variable/nunito'; // This contains ALL variable axes. Font files are larger.
 import '@fontsource-variable/nunito/wght-italic.css'; // Italic variant.
@@ -32,23 +32,23 @@ const StorefrontComponent = ({ state }) => {
 
   const launchSuccessToast = (message) => {
     toast.success(`${message}`, {
-      position: "bottom-center",
+      position: 'bottom-center',
       autoClose: 1000,
       hideProgressBar: true,
       closeOnClick: true,
       pauseOnHover: false,
-      draggable: false
+      draggable: false,
     });
   };
 
   const launchErrorToast = (message) => {
     toast.error(`${message}`, {
-      position: "bottom-center",
+      position: 'bottom-center',
       autoClose: 1500,
       hideProgressBar: true,
       closeOnClick: true,
       pauseOnHover: false,
-      draggable: false
+      draggable: false,
     });
   };
 
@@ -72,7 +72,10 @@ const StorefrontComponent = ({ state }) => {
       return;
     }
 
-    copyToClipboard(`Theme name: ${state.storefrontInformation.theme.name}\n\nPreview: ${previewUrl}\nEditor: ${editorUrl}`, 'Preview & Editor URL copied');
+    copyToClipboard(
+      `Theme name: ${state.storefrontInformation.theme.name}\n\nPreview: ${previewUrl}\nEditor: ${editorUrl}`,
+      'Preview & Editor URL copied'
+    );
   };
 
   const copyThemeId = () => {
@@ -102,7 +105,6 @@ const StorefrontComponent = ({ state }) => {
   const previewUrlAvailable = Boolean(getPreviewURL());
   const editorUrlAvailable = Boolean(getEditorURL());
 
-
   return (
     <div className="popup-container popup-storefront">
       <div className="popup-body">
@@ -126,21 +128,41 @@ const StorefrontComponent = ({ state }) => {
                 Generate Preview or Preview &amp; Editor URL to this theme.
               </p>
 
-              <div className='generator-actions'>
-                <button className='button' title="Copy theme ID" onClick={() => copyThemeId()}>
+              <div className="generator-actions">
+                <button
+                  className="button"
+                  title="Copy theme ID"
+                  onClick={() => copyThemeId()}
+                >
                   Theme ID
                 </button>
-                <button className='button' title="Copy preview URL" onClick={() => copyPreviewURL()} disabled={!previewUrlAvailable}>
+                <button
+                  className="button"
+                  title="Copy preview URL"
+                  onClick={() => copyPreviewURL()}
+                  disabled={!previewUrlAvailable}
+                >
                   Preview URL
                 </button>
-                <button className='button' title="Copy preview &amp; editor URLs" onClick={() => copyPreviewAndEditorURL()} disabled={!previewUrlAvailable || !editorUrlAvailable}>
+                <button
+                  className="button"
+                  title="Copy preview &amp; editor URLs"
+                  onClick={() => copyPreviewAndEditorURL()}
+                  disabled={!previewUrlAvailable || !editorUrlAvailable}
+                >
                   Preview &amp; Editor URL
                 </button>
               </div>
             </div>
           </div>
           <footer className="Panel__Footer">
-            <a href="https://github.com/ConduciveMammal/theme-explorer/issues" target="_blank" rel="noreferrer">Report an issue</a>
+            <a
+              href="https://github.com/ConduciveMammal/theme-explorer/issues"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Report an issue
+            </a>
           </footer>
         </div>
         <ToastContainer />
@@ -148,6 +170,5 @@ const StorefrontComponent = ({ state }) => {
     </div>
   );
 };
-
 
 export default StorefrontComponent;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,6 +23,10 @@
   "permissions": [
     "tabs"
   ],
+  "host_permissions": [
+    "https://admin.shopify.com/*",
+    "https://*.myshopify.com/*"
+  ],
   "background": {
     "service_worker": "src/pages/Background/index.js",
     "type": "module"

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -26,7 +26,18 @@ appendInjectScript('src/pages/Inject/index.js', (event) => {
 //   }
 // }
 function sendMessageToReact(objectData, isPopupOpen = false) {
-  chrome.runtime.sendMessage(chrome.runtime.id, objectData);
+  if (!objectData) {
+    return;
+  }
+
+  chrome.runtime.sendMessage(chrome.runtime.id, objectData, () => {
+    if (chrome.runtime.lastError) {
+      console.debug(
+        'Theme Explorer: runtime message skipped:',
+        chrome.runtime.lastError.message
+      );
+    }
+  });
 
   if (!isPopupOpen) {
     data = objectData;
@@ -36,7 +47,11 @@ function sendMessageToReact(objectData, isPopupOpen = false) {
 window.addEventListener(
   'message',
   (e) => {
-    if (e.data.type === 'theme') {
+    if (e.source !== window || e.origin !== window.location.origin) {
+      return;
+    }
+
+    if (e.data && e.data.type === 'theme' && e.data.data) {
       sendMessageToReact(e.data);
     }
   },
@@ -45,6 +60,13 @@ window.addEventListener(
 
 chrome.runtime.onMessage.addListener((request) => {
   if (request.popupIsOpen) {
+    if (!data) {
+      appendInjectScript('src/pages/Inject/index.js', (event) => {
+        console.error('Error reloading script for popup request:', event);
+      });
+      return;
+    }
+
     sendMessageToReact(data, true);
   }
 });

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -1,4 +1,6 @@
 let data = null;
+const MESSAGE_PORT_CLOSED_ERROR =
+  'The message port closed before a response was received.';
 
 function appendInjectScript(srcPath, onError) {
   const script = document.createElement('script');
@@ -32,10 +34,12 @@ function sendMessageToReact(objectData, isPopupOpen = false) {
 
   chrome.runtime.sendMessage(chrome.runtime.id, objectData, () => {
     if (chrome.runtime.lastError) {
-      console.debug(
-        'Theme Explorer: runtime message skipped:',
-        chrome.runtime.lastError.message
-      );
+      const errorMessage = chrome.runtime.lastError.message || '';
+      if (errorMessage.includes(MESSAGE_PORT_CLOSED_ERROR)) {
+        return;
+      }
+
+      console.debug('Theme Explorer: runtime message skipped:', errorMessage);
     }
   });
 

--- a/src/pages/Inject/index.js
+++ b/src/pages/Inject/index.js
@@ -1,26 +1,99 @@
-function getThemeDataAndSendItToExt() {
-  if (window.location.href.includes('admin.shopify.com/store')) return;
+const MAX_SHOPIFY_LOOKUP_ATTEMPTS = 20;
+const RETRY_INTERVAL_MS = 500;
 
-  if (window.Shopify && (Shopify.theme || Shopify.shop)) {
-    // console.log('Shopify', Shopify);
-    const themeData = {
-      type: 'theme',
-      data: {
-        theme: Shopify.theme
-          ? {
-              handle: Shopify.theme.handle,
-              id: Shopify.theme.id,
-              name: Shopify.theme.name,
-              role: Shopify.theme.role,
-            }
-          : undefined,
-        shop: Shopify.shop,
-        location: window.location.href,
-      },
-    };
+let retryTimer = null;
+let lookupAttempts = 0;
+let hasPostedThemeData = false;
 
-    window.postMessage(themeData, window.location.origin);
+function shouldSkipInjection() {
+  return window.location.href.includes('admin.shopify.com/store');
+}
+
+function getThemeData() {
+  const shopify = window.Shopify;
+
+  if (!shopify || (!shopify.theme && !shopify.shop)) {
+    return null;
+  }
+
+  const theme =
+    shopify.theme && shopify.theme.id
+      ? {
+          handle: shopify.theme.handle,
+          id: shopify.theme.id,
+          name: shopify.theme.name,
+          role: shopify.theme.role,
+        }
+      : undefined;
+
+  const shop = typeof shopify.shop === 'string' ? shopify.shop : null;
+
+  if (!theme && !shop) {
+    return null;
+  }
+
+  return {
+    type: 'theme',
+    data: {
+      theme,
+      shop,
+      location: window.location.href,
+    },
+  };
+}
+
+function postThemeData() {
+  const themeData = getThemeData();
+
+  if (!themeData) {
+    return false;
+  }
+
+  window.postMessage(themeData, window.location.origin);
+  hasPostedThemeData = true;
+  return true;
+}
+
+function stopRetryLoop() {
+  if (!retryTimer) {
+    return;
+  }
+
+  window.clearInterval(retryTimer);
+  retryTimer = null;
+}
+
+function runThemeLookup() {
+  if (shouldSkipInjection() || hasPostedThemeData) {
+    stopRetryLoop();
+    return;
+  }
+
+  lookupAttempts += 1;
+
+  if (postThemeData()) {
+    stopRetryLoop();
+    return;
+  }
+
+  if (lookupAttempts >= MAX_SHOPIFY_LOOKUP_ATTEMPTS) {
+    console.debug(
+      'Theme Explorer: Shopify data was not available after retry limit.'
+    );
+    stopRetryLoop();
   }
 }
 
-getThemeDataAndSendItToExt();
+function scheduleRetryLoop() {
+  if (retryTimer || hasPostedThemeData || shouldSkipInjection()) {
+    return;
+  }
+
+  retryTimer = window.setInterval(runThemeLookup, RETRY_INTERVAL_MS);
+}
+
+runThemeLookup();
+scheduleRetryLoop();
+
+document.addEventListener('DOMContentLoaded', runThemeLookup, { once: true });
+window.addEventListener('load', runThemeLookup, { once: true });

--- a/src/pages/Inject/index.js
+++ b/src/pages/Inject/index.js
@@ -1,99 +1,101 @@
-const MAX_SHOPIFY_LOOKUP_ATTEMPTS = 20;
-const RETRY_INTERVAL_MS = 500;
+(() => {
+  const MAX_SHOPIFY_LOOKUP_ATTEMPTS = 20;
+  const RETRY_INTERVAL_MS = 500;
 
-let retryTimer = null;
-let lookupAttempts = 0;
-let hasPostedThemeData = false;
+  let retryTimer = null;
+  let lookupAttempts = 0;
+  let hasPostedThemeData = false;
 
-function shouldSkipInjection() {
-  return window.location.href.includes('admin.shopify.com/store');
-}
-
-function getThemeData() {
-  const shopify = window.Shopify;
-
-  if (!shopify || (!shopify.theme && !shopify.shop)) {
-    return null;
+  function shouldSkipInjection() {
+    return window.location.href.includes('admin.shopify.com/store');
   }
 
-  const theme =
-    shopify.theme && shopify.theme.id
-      ? {
-          handle: shopify.theme.handle,
-          id: shopify.theme.id,
-          name: shopify.theme.name,
-          role: shopify.theme.role,
-        }
-      : undefined;
+  function getThemeData() {
+    const shopify = window.Shopify;
 
-  const shop = typeof shopify.shop === 'string' ? shopify.shop : null;
+    if (!shopify || (!shopify.theme && !shopify.shop)) {
+      return null;
+    }
 
-  if (!theme && !shop) {
-    return null;
+    const theme =
+      shopify.theme && shopify.theme.id
+        ? {
+            handle: shopify.theme.handle,
+            id: shopify.theme.id,
+            name: shopify.theme.name,
+            role: shopify.theme.role,
+          }
+        : undefined;
+
+    const shop = typeof shopify.shop === 'string' ? shopify.shop : null;
+
+    if (!theme && !shop) {
+      return null;
+    }
+
+    return {
+      type: 'theme',
+      data: {
+        theme,
+        shop,
+        location: window.location.href,
+      },
+    };
   }
 
-  return {
-    type: 'theme',
-    data: {
-      theme,
-      shop,
-      location: window.location.href,
-    },
-  };
-}
+  function postThemeData() {
+    const themeData = getThemeData();
 
-function postThemeData() {
-  const themeData = getThemeData();
+    if (!themeData) {
+      return false;
+    }
 
-  if (!themeData) {
-    return false;
+    window.postMessage(themeData, window.location.origin);
+    hasPostedThemeData = true;
+    return true;
   }
 
-  window.postMessage(themeData, window.location.origin);
-  hasPostedThemeData = true;
-  return true;
-}
+  function stopRetryLoop() {
+    if (!retryTimer) {
+      return;
+    }
 
-function stopRetryLoop() {
-  if (!retryTimer) {
-    return;
+    window.clearInterval(retryTimer);
+    retryTimer = null;
   }
 
-  window.clearInterval(retryTimer);
-  retryTimer = null;
-}
+  function runThemeLookup() {
+    if (shouldSkipInjection() || hasPostedThemeData) {
+      stopRetryLoop();
+      return;
+    }
 
-function runThemeLookup() {
-  if (shouldSkipInjection() || hasPostedThemeData) {
-    stopRetryLoop();
-    return;
+    lookupAttempts += 1;
+
+    if (postThemeData()) {
+      stopRetryLoop();
+      return;
+    }
+
+    if (lookupAttempts >= MAX_SHOPIFY_LOOKUP_ATTEMPTS) {
+      console.debug(
+        'Theme Explorer: Shopify data was not available after retry limit.'
+      );
+      stopRetryLoop();
+    }
   }
 
-  lookupAttempts += 1;
+  function scheduleRetryLoop() {
+    if (retryTimer || hasPostedThemeData || shouldSkipInjection()) {
+      return;
+    }
 
-  if (postThemeData()) {
-    stopRetryLoop();
-    return;
+    retryTimer = window.setInterval(runThemeLookup, RETRY_INTERVAL_MS);
   }
 
-  if (lookupAttempts >= MAX_SHOPIFY_LOOKUP_ATTEMPTS) {
-    console.debug(
-      'Theme Explorer: Shopify data was not available after retry limit.'
-    );
-    stopRetryLoop();
-  }
-}
+  runThemeLookup();
+  scheduleRetryLoop();
 
-function scheduleRetryLoop() {
-  if (retryTimer || hasPostedThemeData || shouldSkipInjection()) {
-    return;
-  }
-
-  retryTimer = window.setInterval(runThemeLookup, RETRY_INTERVAL_MS);
-}
-
-runThemeLookup();
-scheduleRetryLoop();
-
-document.addEventListener('DOMContentLoaded', runThemeLookup, { once: true });
-window.addEventListener('load', runThemeLookup, { once: true });
+  document.addEventListener('DOMContentLoaded', runThemeLookup, { once: true });
+  window.addEventListener('load', runThemeLookup, { once: true });
+})();

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -10,6 +10,9 @@ import StorefrontComponent from '../../containers/StorefrontComponent/Storefront
 import NotFound from '../../containers/NotFound/NotFound';
 
 const Popup = () => {
+  const MESSAGE_PORT_CLOSED_ERROR =
+    'The message port closed before a response was received.';
+
   const [state, setState] = useState({
     themes: null,
     themesReady: false,
@@ -212,9 +215,14 @@ const Popup = () => {
         { popupIsOpen: true },
         () => {
           if (chrome.runtime.lastError) {
+            const errorMessage = chrome.runtime.lastError.message || '';
+            if (errorMessage.includes(MESSAGE_PORT_CLOSED_ERROR)) {
+              return;
+            }
+
             console.debug(
               'Theme Explorer: popup message not delivered:',
-              chrome.runtime.lastError.message
+              errorMessage
             );
           }
         }

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -19,14 +19,17 @@ const Popup = () => {
     storeUrl: null,
     storeHandle: '',
     currentTab: null,
+    urls: null,
+    shop: null,
+    loadError: false,
   });
 
   const getLiveTheme = useCallback(() => {
     if (!state.themes) return;
 
-    const liveTheme = state.themes.find(theme => theme.role === 'main');
+    const liveTheme = state.themes.find((theme) => theme.role === 'main');
     if (liveTheme) {
-      setState(prevState => ({ ...prevState, liveTheme }));
+      setState((prevState) => ({ ...prevState, liveTheme }));
     }
   }, [state.themes]);
 
@@ -34,100 +37,144 @@ const Popup = () => {
     if (!state.storeUrl) return;
 
     try {
-      // console.log('shop state', state);
       const response = await fetch(`${state.storeUrl}/shop.json`);
-      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(`Store request failed with status ${response.status}`);
+      }
 
-      setState(prevState => ({
+      const data = await response.json();
+      const storeHandle = data?.shop?.domain?.split('.myshopify.com')[0] || '';
+
+      setState((prevState) => ({
         ...prevState,
-        shop: data.shop,
-        storeHandle: data.shop.domain.split('.myshopify.com')[0]
+        shop: data?.shop || null,
+        storeHandle,
+        loadError: false,
       }));
     } catch (error) {
-      console.error('Failed to fetch store: ', error)
+      console.error('Failed to fetch store:', error);
+      setState((prevState) => ({
+        ...prevState,
+        loadError: true,
+      }));
     }
   };
 
   const getCurrentTab = async () => {
-    let queryOptions = { active: true, currentWindow: true };
-    // `tab` will either be a `tabs.Tab` instance or `undefined`.
-    let [tab] = await chrome.tabs.query(queryOptions);
+    try {
+      const queryOptions = { active: true, currentWindow: true };
+      const [tab] = await chrome.tabs.query(queryOptions);
 
-    setState((prevState) => ({
-      ...prevState,
-      currentTab: tab,
-    }));
+      setState((prevState) => ({
+        ...prevState,
+        currentTab: tab || null,
+      }));
 
-    getTabData(tab);
+      getTabData(tab);
+    } catch (error) {
+      console.error('Failed to get current tab:', error);
+      setState((prevState) => ({
+        ...prevState,
+        loadError: true,
+      }));
+    }
   };
 
   const getTabData = async (tab) => {
-    if (!tab) return;
-
-    // const tabUrl = await new URL(tab.url);
+    if (!tab || !tab.url) return;
     const tabUrl = parseUrl(tab.url);
 
-    // console.log('t', tab);
-    // console.log(tabUrl);
-
+    if (!tabUrl) {
+      setState((prevState) => ({
+        ...prevState,
+        adminShown: false,
+        storeUrl: null,
+      }));
+      return;
+    }
 
     setState((prevState) => ({
       ...prevState,
       adminShown: tabUrl.host.includes('admin.shopify.com'),
-      storeUrl: `${tabUrl.protocol}//${tabUrl.host}/store/${tabUrl.storeHandle}`,
+      storeUrl: tabUrl.storeHandle
+        ? `${tabUrl.protocol}//${tabUrl.host}/store/${tabUrl.storeHandle}`
+        : null,
     }));
-    // console.log('Tab', `${tabUrl.protocol}//${tabUrl.host}/store/${tabUrl.storeHandle}`);
   };
 
   function parseUrl(url) {
-    const parsedUrl = new URL(url);
-    const urlSegments = parsedUrl.pathname.split('/').filter(segment => segment !== '')
-    return {
-      fullUrl: url,
-      protocol: parsedUrl.protocol,
-      host: parsedUrl.host,
-      storeHandle: urlSegments[1],
-      currentPage: urlSegments[2]
-    };
+    try {
+      const parsedUrl = new URL(url);
+      if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+        return null;
+      }
+
+      const urlSegments = parsedUrl.pathname
+        .split('/')
+        .filter((segment) => segment !== '');
+      return {
+        fullUrl: url,
+        protocol: parsedUrl.protocol,
+        host: parsedUrl.host,
+        storeHandle: urlSegments[1] || '',
+        currentPage: urlSegments[2] || '',
+      };
+    } catch (error) {
+      console.debug('Theme Explorer: failed to parse tab URL:', url);
+      return null;
+    }
   }
 
   const fetchThemes = async () => {
     if (!state.storeUrl || !state.adminShown) return;
 
-    await fetch(`${state.storeUrl}/themes.json`)
-      .then((response) => response.text())
-      .then((data) => {
-        const themesArray = JSON.parse(data);
+    try {
+      const response = await fetch(`${state.storeUrl}/themes.json`);
+      if (!response.ok) {
+        throw new Error(`Theme request failed with status ${response.status}`);
+      }
 
-        setState((prevState) => ({
-          ...prevState,
-          themes: themesArray.themes,
-        }));
-      })
-      .then(() => {
-        fetchStore();
+      const themesArray = await response.json();
+      setState((prevState) => ({
+        ...prevState,
+        themes: themesArray?.themes || [],
+        themesReady: true,
+        loadError: false,
+      }));
 
-        setState((prevState) => ({
-          ...prevState,
-          themesReady: true,
-        }));
-      });
+      fetchStore();
+    } catch (error) {
+      console.error('Failed to fetch themes:', error);
+      setState((prevState) => ({
+        ...prevState,
+        themes: [],
+        themesReady: true,
+        loadError: true,
+      }));
+    }
   };
 
   const registerOnMessage = (request) => {
-    // console.log('loloo', request);
-    const storeHandle = request.data.shop.split('.myshopify.com')[0];
-
-    if (request.type === 'theme') {
-      setState((prevState) => ({
-        ...prevState,
-        storefrontInformation: request.data.hasOwnProperty('theme') ? request.data : null,
-        storeHandle,
-        urls: {
-          adminBase: `admin.shopify.com/store/${storeHandle}`
-        }
-      }));
+    if (!request || request.type !== 'theme' || !request.data) {
+      return;
     }
+
+    const shopDomain =
+      typeof request.data.shop === 'string' ? request.data.shop : '';
+    const storeHandle = shopDomain.endsWith('.myshopify.com')
+      ? shopDomain.split('.myshopify.com')[0]
+      : '';
+
+    setState((prevState) => ({
+      ...prevState,
+      storefrontInformation: request.data.theme ? request.data : null,
+      storeHandle: storeHandle || prevState.storeHandle,
+      urls: storeHandle
+        ? {
+            adminBase: `admin.shopify.com/store/${storeHandle}`,
+          }
+        : prevState.urls,
+    }));
   };
 
   useEffect(() => {
@@ -135,45 +182,47 @@ const Popup = () => {
     // Potentially remove fetchThemes() from here if it's dependent on the result of getCurrentTab()
   }, []); // This runs only once when the component mounts
 
-
   useEffect(() => {
     if (state.storeUrl) {
       fetchThemes();
     }
   }, [state.storeUrl]); // This runs when `state.storeUrl` changes
 
-
-
   useEffect(() => {
     getLiveTheme();
   }, [getLiveTheme]);
 
-//   useEffect(() => {
-//   const handleMessage = (request) => registerOnMessage(request);
+  //   useEffect(() => {
+  //   const handleMessage = (request) => registerOnMessage(request);
 
-//   chrome.runtime.onMessage.addListener(handleMessage);
+  //   chrome.runtime.onMessage.addListener(handleMessage);
 
-//   return () => chrome.runtime.onMessage.removeListener(handleMessage);
-// }, []); // Adjust dependencies based on your needs
+  //   return () => chrome.runtime.onMessage.removeListener(handleMessage);
+  // }, []); // Adjust dependencies based on your needs
 
-useEffect(() => {
-  // Define a function that will handle incoming messages
-  const handleMessage = (request) => {
-    registerOnMessage(request);
-  };
+  useEffect(() => {
+    const handleMessage = (request) => {
+      registerOnMessage(request);
+    };
 
-  // Conditionally add the event listener
-  if (!state.storefrontInformation && state.currentTab && !state.adminShown) {
-    chrome.runtime.onMessage.addListener(handleMessage);
-    chrome.tabs.sendMessage(state.currentTab.id, { popupIsOpen: true });
+    if (!state.storefrontInformation && state.currentTab && !state.adminShown) {
+      chrome.runtime.onMessage.addListener(handleMessage);
+      chrome.tabs.sendMessage(
+        state.currentTab.id,
+        { popupIsOpen: true },
+        () => {
+          if (chrome.runtime.lastError) {
+            console.debug(
+              'Theme Explorer: popup message not delivered:',
+              chrome.runtime.lastError.message
+            );
+          }
+        }
+      );
 
-    // Return a cleanup function that removes the event listener
-    return () => chrome.runtime.onMessage.removeListener(handleMessage);
-  }
-
-  // This effect should depend on the state that dictates whether the listener should be added or removed
-}, [state.storefrontInformation, state.currentTab, state.adminShown]); // Adjust this array based on actual dependencies
-
+      return () => chrome.runtime.onMessage.removeListener(handleMessage);
+    }
+  }, [state.storefrontInformation, state.currentTab, state.adminShown]);
 
   // if (!state.storefrontInformation && state.currentTab && !state.adminShown) {
   //   chrome.runtime.onMessage.addListener((request) =>
@@ -188,9 +237,20 @@ useEffect(() => {
 
   if (state.storefrontInformation) {
     return <StorefrontComponent state={state} />;
-  } else if (state.adminShown && state.themesReady && state.shop && !state.storefrontInformation) {
+  } else if (state.loadError) {
+    return <NotFound />;
+  } else if (
+    state.adminShown &&
+    state.themesReady &&
+    state.shop &&
+    !state.storefrontInformation
+  ) {
     return <AdminComponent state={state} />;
-  } else if (!state.storefrontInformation && !state.adminShown && !state.themesReady) {
+  } else if (
+    !state.storefrontInformation &&
+    !state.adminShown &&
+    !state.themesReady
+  ) {
     return <NotFound />;
   } else {
     return <LoadingComponent />;

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig(({ mode }) => {
   if (isDevelopment) {
     manifest.content_security_policy = {
       extension_pages:
-        "script-src 'self'; object-src 'self'; connect-src 'self' http://localhost:5173 ws://localhost:5173 http://127.0.0.1:5173 ws://127.0.0.1:5173;",
+        "script-src 'self'; object-src 'self'; connect-src 'self' https://admin.shopify.com https://*.myshopify.com http://localhost:5173 ws://localhost:5173 http://127.0.0.1:5173 ws://127.0.0.1:5173;",
     };
   }
 


### PR DESCRIPTION
## Summary
This PR completes THE-8 by hardening Shopify data extraction and extension messaging reliability across inject, content, and popup layers.

### What changed
- Use Shopify.shop as the canonical domain when generating storefront preview URLs.
- Harden storefront copy actions with explicit unavailable/error handling and disabled button states.
- Add inject-script retry logic for late-loaded window.Shopify data.
- Validate content-script postMessage origin/source/payload before forwarding.
- Recover when popup requests data before inject has produced it.
- Improve popup resilience around tab URL parsing, fetch failures, and fallback rendering.
- Allow required Shopify hosts in extension fetch policy (development CSP plus host permissions).
- Suppress expected closed-port noise while keeping unexpected runtime messaging errors visible.

## Why
- Prevents local preview URLs being copied instead of permanent shop URLs.
- Avoids brittle failures when Shopify globals load late or messaging arrives out of order.
- Keeps failure modes graceful and debuggable.
- Restores admin data fetch behaviour under development CSP constraints.

## Validation
- [x] npm run build:dev
- [x] Manual check: admin page no longer blocked by CSP when requesting themes.json and shop.json.
- [x] Manual check: local preview copy outputs https://<shop>.myshopify.com/?preview_theme_id=...
- [x] Manual check: expected closed message-port warning is no longer noisy.

## Risk and rollout
- Low to medium risk: touches core extension communication paths.
- Mitigated by defensive guards, explicit error handling, and successful build validation.

## Linear
- THE-8
