### PR TITLE
THE-10: establish QA smoke tests and release checklist baseline

### DIFF
--- a/.github/workflows/qa-release-candidate.yml
+++ b/.github/workflows/qa-release-candidate.yml
@@ -2,8 +2,6 @@ name: QA Release Candidate
 
 on:
   pull_request:
-    branches:
-      - codex/theme-explorer-v2
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/qa-release-candidate.yml
+++ b/.github/workflows/qa-release-candidate.yml
@@ -1,0 +1,28 @@
+name: QA Release Candidate
+
+on:
+  pull_request:
+    branches:
+      - codex/theme-explorer-v2
+  workflow_dispatch:
+
+jobs:
+  qa-release-candidate:
+    name: Validate QA release candidate build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run QA release candidate checks
+        run: npm run qa:release-candidate

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ _Note: Firefox requires at least version 109.0_
 - `npm run dev:watch`: stable watch build to `build-vite` (fallback if HMR is blocked)
 - `npm run build:dev`: one-off development build to `build-vite`
 - `npm run build:prod` or `npm run build`: production build to `build-vite`
+- `npm run qa:verify-build`: verifies release build artefacts and manifest integrity
+- `npm run qa:release-candidate`: runs production build and QA verification
+
+## QA
+
+- Smoke test plan: `docs/qa/smoke-test-plan.md`
+- Release checklist: `docs/qa/release-checklist.md`
 
 ## Roadmap
 

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -1,0 +1,33 @@
+# Release QA Checklist
+
+Run this checklist for every release candidate.
+
+## 1. Build and artefact verification
+
+- [ ] `npm ci` completed without errors
+- [ ] `npm run qa:release-candidate` passed
+- [ ] `build-vite/manifest.json` version matches `package.json`
+- [ ] Extension loads successfully in Chrome and Firefox
+
+## 2. Manual smoke tests
+
+- [ ] Admin popup smoke test passed
+- [ ] Storefront popup smoke test passed
+- [ ] Content/inject bridge smoke test passed
+- [ ] Background update behaviour smoke test passed
+- [ ] Smoke test sign-off table updated in `docs/qa/smoke-test-plan.md`
+
+## 3. Regression and compatibility checks
+
+- [ ] No new console errors in popup, content, or background contexts
+- [ ] Core styling remains intact in popup views
+- [ ] Required host permissions remain unchanged:
+  - `https://admin.shopify.com/*`
+  - `https://*.myshopify.com/*`
+
+## 4. Release readiness
+
+- [ ] `CHANGELOG.md` updated for the candidate version
+- [ ] Candidate build reviewed by at least one other person (when available)
+- [ ] Linear ticket `THE-10` checklist evidence attached or linked
+- [ ] Final go/no-go decision recorded

--- a/docs/qa/smoke-test-plan.md
+++ b/docs/qa/smoke-test-plan.md
@@ -1,0 +1,68 @@
+# Smoke Test Plan
+
+## Purpose
+
+Validate the most critical extension flows before any release candidate is published.
+
+## Test Environment
+
+- Chrome latest stable
+- Firefox latest stable
+- Test shop with access to:
+  - Shopify admin (`admin.shopify.com`)
+  - Theme customiser and theme list
+  - Storefront page
+
+## Pre-check
+
+1. Run `npm run qa:release-candidate`.
+2. Load `build-vite` as an unpacked extension in the target browser.
+3. Pin the extension and keep Developer mode enabled.
+
+## Smoke Scenarios
+
+### Popup: Admin flow
+
+1. Open `https://admin.shopify.com/store/<store-handle>/themes`.
+2. Open the extension popup.
+3. Confirm the admin view renders with:
+   - Theme list
+   - Live theme marker
+   - Theme links (customiser, code editor, JSON where available)
+4. Verify no error screen is shown.
+
+Expected result: Admin data loads and popup stays responsive.
+
+### Popup: Storefront flow
+
+1. Open a storefront page on `<store>.myshopify.com`.
+2. Open the extension popup.
+3. Confirm storefront information renders, including active theme details when available.
+4. Reload the storefront page and repeat to confirm data still appears.
+
+Expected result: Storefront panel renders without requiring admin context.
+
+### Content and inject bridge
+
+1. On storefront, open DevTools console.
+2. Confirm there are no recurring errors from:
+   - content script message passing
+   - inject script loading
+3. Open popup and confirm data appears within ~10 seconds.
+
+Expected result: `Inject -> Content -> Popup` communication works and retries recover delayed `window.Shopify` availability.
+
+### Background update behaviour
+
+1. Bump local extension version in `package.json`.
+2. Run `npm run build:dev` and reload extension.
+3. Confirm a single update tab opens to the release URL with `updateFrom` query string.
+
+Expected result: Update flow triggers only on update and opens changelog page.
+
+## Sign-off Record
+
+Use this table for each candidate build.
+
+| Date | Build version | Browser | Tester | Result (Pass/Fail) | Notes |
+| ---- | ------------- | ------- | ------ | ------------------ | ----- |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "build": "vite build --mode production",
     "build:dev": "vite build --mode development",
     "build:prod": "vite build --mode production",
-    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'"
+    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
+    "qa:verify-build": "node scripts/qa/verify-build.js",
+    "qa:release-candidate": "npm run build:prod && npm run qa:verify-build"
   },
   "dependencies": {
     "@fontsource-variable/nunito": "^5.0.16",

--- a/scripts/qa/verify-build.js
+++ b/scripts/qa/verify-build.js
@@ -1,0 +1,113 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..', '..');
+const buildDir = path.join(rootDir, 'build-vite');
+const buildManifestPath = path.join(buildDir, 'manifest.json');
+const packageJsonPath = path.join(rootDir, 'package.json');
+
+function fail(message) {
+  console.error(`✗ ${message}`);
+  process.exitCode = 1;
+}
+
+function pass(message) {
+  console.log(`✓ ${message}`);
+}
+
+function fileExists(relativePath) {
+  return fs.existsSync(path.join(buildDir, relativePath));
+}
+
+function parseJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function assertManifestPathExists(label, relativePath) {
+  if (!relativePath) {
+    fail(`${label} is missing from manifest`);
+    return;
+  }
+
+  if (!fileExists(relativePath)) {
+    fail(`${label} file was not emitted: ${relativePath}`);
+    return;
+  }
+
+  pass(`${label} exists: ${relativePath}`);
+}
+
+function run() {
+  if (!fs.existsSync(buildManifestPath)) {
+    fail(
+      'No build manifest found at build-vite/manifest.json. Run `npm run build:prod` first.'
+    );
+    return;
+  }
+
+  const buildManifest = parseJson(buildManifestPath);
+  const packageJson = parseJson(packageJsonPath);
+
+  if (buildManifest.version !== packageJson.version) {
+    fail(
+      `Build version mismatch. Expected ${packageJson.version}, found ${buildManifest.version}.`
+    );
+  } else {
+    pass(`Manifest version matches package.json (${packageJson.version})`);
+  }
+
+  assertManifestPathExists(
+    'Popup entry',
+    buildManifest.action && buildManifest.action.default_popup
+  );
+
+  assertManifestPathExists(
+    'Background service worker',
+    buildManifest.background && buildManifest.background.service_worker
+  );
+
+  const contentScriptPath =
+    buildManifest.content_scripts &&
+    buildManifest.content_scripts[0] &&
+    buildManifest.content_scripts[0].js &&
+    buildManifest.content_scripts[0].js[0];
+
+  assertManifestPathExists('Content script bundle', contentScriptPath);
+
+  const webAccessibleResourcePath =
+    buildManifest.web_accessible_resources &&
+    buildManifest.web_accessible_resources[0] &&
+    buildManifest.web_accessible_resources[0].resources &&
+    buildManifest.web_accessible_resources[0].resources[0];
+
+  assertManifestPathExists(
+    'Inject script web-accessible resource',
+    webAccessibleResourcePath
+  );
+
+  const hostPermissions = buildManifest.host_permissions || [];
+  const expectedPermissions = [
+    'https://admin.shopify.com/*',
+    'https://*.myshopify.com/*',
+  ];
+
+  expectedPermissions.forEach((permission) => {
+    if (!hostPermissions.includes(permission)) {
+      fail(`Missing host permission: ${permission}`);
+      return;
+    }
+
+    pass(`Host permission present: ${permission}`);
+  });
+
+  if (process.exitCode) {
+    console.error(
+      '\nBuild verification failed. Fix the issues above before releasing.'
+    );
+    return;
+  }
+
+  console.log('\nBuild verification passed. Ready for manual smoke checks.');
+}
+
+run();


### PR DESCRIPTION
## Summary
- Add automated release build verification script
- Add smoke test plan for popup/content/inject/background flows
- Add repeatable release QA checklist
- Document QA commands and references in README

## Validation
- `npm run qa:release-candidate`

## Notes
- Manual smoke execution and checklist sign-off are tracked in `docs/qa/smoke-test-plan.md` and `docs/qa/release-checklist.md`.
