### PR TITLE
THE-14: add release pipeline and rollback plan

### DIFF
--- a/.github/workflows/qa-release-candidate.yml
+++ b/.github/workflows/qa-release-candidate.yml
@@ -24,3 +24,32 @@ jobs:
 
       - name: Run QA release candidate checks
         run: npm run qa:release-candidate
+
+      - name: Capture release candidate metadata
+        run: |
+          echo "VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_ENV"
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Archive build artefact
+        run: |
+          cd build-vite
+          zip -r "../theme-explorer-v${VERSION}-${SHORT_SHA}.zip" .
+
+      - name: Upload build artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: theme-explorer-v${{ env.VERSION }}-${{ env.SHORT_SHA }}
+          path: theme-explorer-v${{ env.VERSION }}-${{ env.SHORT_SHA }}.zip
+          if-no-files-found: error
+
+      - name: Workflow summary
+        run: |
+          {
+            echo "## QA Release Candidate";
+            echo "";
+            echo "- Version: \`${VERSION}\`";
+            echo "- Commit: \`${SHORT_SHA}\`";
+            echo "- Artefact: \`theme-explorer-v${VERSION}-${SHORT_SHA}.zip\`";
+            echo "";
+            echo "Next step: run the manual checks in \`docs/qa/release-checklist.md\`.";
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -2,6 +2,10 @@
 
 Run this checklist for every release candidate.
 
+Reference runbooks:
+- `docs/qa/release-pipeline.md`
+- `docs/qa/rollback-plan.md`
+
 ## 1. Build and artefact verification
 
 - [ ] `npm ci` completed without errors
@@ -29,5 +33,7 @@ Run this checklist for every release candidate.
 
 - [ ] `CHANGELOG.md` updated for the candidate version
 - [ ] Candidate build reviewed by at least one other person (when available)
-- [ ] Linear ticket `THE-10` checklist evidence attached or linked
+- [ ] CI artefact downloaded from `QA Release Candidate` workflow and linked in ticket
+- [ ] Rollback path validated against `docs/qa/rollback-plan.md`
+- [ ] Linear ticket `THE-14` checklist evidence attached or linked
 - [ ] Final go/no-go decision recorded

--- a/docs/qa/release-pipeline.md
+++ b/docs/qa/release-pipeline.md
@@ -1,0 +1,53 @@
+# Release Pipeline
+
+This runbook defines the release candidate pipeline for Theme Explorer V2.
+
+## Objective
+
+Produce a repeatable release artefact, validate it, and capture sign-off evidence before publishing.
+
+## Roles
+
+- Release owner: runs the pipeline and records go/no-go.
+- Reviewer: validates manual smoke checks and reviews evidence.
+
+## Pipeline Stages
+
+## 1. Prepare candidate
+
+1. Confirm all intended changes are merged into `codex/theme-explorer-v2`.
+2. Confirm `package.json` version is correct for the candidate.
+3. Update `CHANGELOG.md` with user-facing changes for that version.
+
+## 2. Build and validate
+
+1. Run `npm ci`.
+2. Run `npm run qa:release-candidate`.
+3. Verify local output in `build-vite/`.
+
+## 3. CI candidate artefact
+
+1. Open the `QA Release Candidate` GitHub Actions workflow run for the branch/PR.
+2. Confirm all workflow steps pass.
+3. Download the generated artefact:
+   - `theme-explorer-v<version>-<short-sha>.zip`
+4. Record the workflow URL in the Linear issue and/or release notes.
+
+## 4. Manual smoke and compatibility checks
+
+1. Execute `docs/qa/smoke-test-plan.md` in Chrome latest stable.
+2. Execute `docs/qa/smoke-test-plan.md` in Firefox latest stable.
+3. Complete all checks in `docs/qa/release-checklist.md`.
+
+## 5. Go/no-go and publish
+
+1. If all checks pass, record `Go` with date and owner.
+2. If any release-blocking issue is found, record `No-go` and follow `docs/qa/rollback-plan.md`.
+3. Publish only after evidence is linked in the tracking ticket.
+
+## Evidence required
+
+- Passing `QA Release Candidate` workflow run URL
+- Smoke-test sign-off table rows
+- Completed release checklist
+- Final go/no-go decision note

--- a/docs/qa/rollback-plan.md
+++ b/docs/qa/rollback-plan.md
@@ -1,0 +1,55 @@
+# Rollback Plan
+
+Use this plan when a release candidate or published release introduces critical regressions.
+
+## Rollback Triggers
+
+Trigger rollback if any of the following is true:
+
+- Extension fails to load in Chrome or Firefox
+- Core popup flows are broken (admin or storefront)
+- Repeated runtime errors affect normal usage
+- Permissions or security posture regresses
+
+## Rollback Strategy
+
+Theme Explorer rollback is version-based:
+
+1. Stop rollout of the current candidate/release.
+2. Revert to the most recent known-good version.
+3. Publish hotfix only after cause is identified and validated.
+
+## Immediate Response Checklist
+
+1. Mark release decision as `No-go` in the current ticket/checklist.
+2. Record incident summary:
+   - detected time
+   - affected browser(s)
+   - impact level
+   - owner
+3. Link failing evidence (console logs, screenshots, workflow URL).
+
+## Execution Steps
+
+1. Identify last known-good tag/commit.
+2. Create rollback branch from the known-good commit.
+3. Build and verify rollback candidate:
+   - `npm ci`
+   - `npm run qa:release-candidate`
+4. Re-run smoke scenarios from `docs/qa/smoke-test-plan.md`.
+5. Publish rollback build and confirm issue is resolved.
+
+## Post-rollback Requirements
+
+1. Document root cause and remediation actions.
+2. Create follow-up issue(s) for prevention work.
+3. Validate rollback with one additional reviewer when available.
+4. Update `CHANGELOG.md` and ticket evidence with rollback context.
+
+## Recovery Exit Criteria
+
+Rollback is complete only when:
+
+- Known-good behaviour is restored in Chrome and Firefox
+- No critical regressions remain open
+- Release owner records final recovery sign-off


### PR DESCRIPTION
## Summary
- add a formal release pipeline runbook for candidate preparation, validation, CI artefacts, and sign-off
- add a rollback plan with triggers, execution checklist, and recovery exit criteria
- update the QA Release Candidate workflow to create and upload a versioned build artefact zip
- update the release checklist to reference the new runbooks and THE-14 evidence

## Files changed
- .github/workflows/qa-release-candidate.yml
- docs/qa/release-checklist.md
- docs/qa/release-pipeline.md
- docs/qa/rollback-plan.md

## Validation
- npm run qa:release-candidate
