### PR TITLE
THE-7: Cross-browser MV3 parity fixes for Firefox and Chrome

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "react-app",
   "globals": {
+    "browser": "readonly",
     "chrome": "readonly",
     "Shopify": "readonly"
   }

--- a/docs/qa/cross-browser-parity.md
+++ b/docs/qa/cross-browser-parity.md
@@ -1,0 +1,31 @@
+# Cross-Browser MV3 Parity (THE-7)
+
+## Purpose
+
+Track Chrome and Firefox parity checks for Theme Explorer V2 under Manifest V3.
+
+## Browser Matrix
+
+- Chrome latest stable
+- Firefox latest stable (minimum supported version: 109.0)
+
+## Core Journeys
+
+- Popup on Shopify admin (`admin.shopify.com/store/<handle>/themes`)
+- Popup on Shopify storefront (`<store>.myshopify.com` and custom storefront domains)
+- Inject -> Content -> Popup message flow
+- Extension update flow (background install/update handling)
+
+## Known Non-Blocking Differences
+
+- None currently recorded.
+
+## Verification Notes
+
+- Runtime APIs now resolve through `browser` or `chrome` to avoid browser-specific global assumptions.
+- Content script runtime messaging avoids extension-ID addressing, improving Firefox compatibility for internal messaging.
+- Manifest enforces Firefox minimum version (`109.0`) to match documented support.
+
+## Evidence
+
+Record test evidence here or link to the relevant Linear comments/attachments for `THE-7`.

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -25,6 +25,7 @@ Reference runbooks:
 
 - [ ] No new console errors in popup, content, or background contexts
 - [ ] Core styling remains intact in popup views
+- [ ] Cross-browser parity notes updated in `docs/qa/cross-browser-parity.md`
 - [ ] Required host permissions remain unchanged:
   - `https://admin.shopify.com/*`
   - `https://*.myshopify.com/*`

--- a/scripts/qa/verify-build.js
+++ b/scripts/qa/verify-build.js
@@ -61,10 +61,20 @@ function run() {
     buildManifest.action && buildManifest.action.default_popup
   );
 
-  assertManifestPathExists(
-    'Background service worker',
-    buildManifest.background && buildManifest.background.service_worker
-  );
+  const backgroundServiceWorkerPath =
+    buildManifest.background && buildManifest.background.service_worker;
+  const backgroundScriptPath =
+    buildManifest.background &&
+    buildManifest.background.scripts &&
+    buildManifest.background.scripts[0];
+
+  if (backgroundServiceWorkerPath) {
+    assertManifestPathExists('Background service worker', backgroundServiceWorkerPath);
+  } else if (backgroundScriptPath) {
+    assertManifestPathExists('Background script', backgroundScriptPath);
+  } else {
+    fail('Background entry is missing from manifest');
+  }
 
   const contentScriptPath =
     buildManifest.content_scripts &&

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1,24 +1,32 @@
 const updateUrlBase = 'https://theme-explorer.merlyndesignworks.co.uk/releases';
+const extensionApi =
+  (typeof browser !== 'undefined' && browser) ||
+  (typeof chrome !== 'undefined' && chrome) ||
+  null;
 
-chrome.runtime.onInstalled.addListener((details) => {
-  const currentVersion = chrome.runtime.getManifest().version;
-  const previousVersion = details.previousVersion;
-  const reason = details.reason;
+if (extensionApi?.runtime?.onInstalled?.addListener) {
+  extensionApi.runtime.onInstalled.addListener((details) => {
+    const currentVersion = extensionApi.runtime.getManifest().version;
+    const previousVersion = details.previousVersion;
+    const reason = details.reason;
 
-  switch (reason) {
-    case 'install':
-      console.log('New User installed the extension.');
-      break;
-    case 'update':
-      chrome.tabs.create({
-        url: `${updateUrlBase}/${currentVersion.replaceAll(
-          '.',
-          '_'
-        )}?updateFrom=${previousVersion}`,
-        active: true,
-      });
-      break;
-    default:
-      break;
-  }
-});
+    switch (reason) {
+      case 'install':
+        console.log('New User installed the extension.');
+        break;
+      case 'update':
+        if (extensionApi?.tabs?.create) {
+          extensionApi.tabs.create({
+            url: `${updateUrlBase}/${currentVersion.replaceAll(
+              '.',
+              '_'
+            )}?updateFrom=${previousVersion}`,
+            active: true,
+          });
+        }
+        break;
+      default:
+        break;
+    }
+  });
+}

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -1,6 +1,10 @@
+import getExtensionApi from '../../utils/getExtensionApi';
+
 let data = null;
 const MESSAGE_PORT_CLOSED_ERROR =
   'The message port closed before a response was received.';
+
+const extensionApi = getExtensionApi();
 
 function parseThemeObject(scriptText) {
   if (!scriptText) {
@@ -73,8 +77,12 @@ function getFallbackThemeData() {
 }
 
 function appendInjectScript(srcPath, onError) {
+  if (!extensionApi?.runtime?.getURL) {
+    return;
+  }
+
   const script = document.createElement('script');
-  script.src = chrome.runtime.getURL(srcPath);
+  script.src = extensionApi.runtime.getURL(srcPath);
   script.onload = function () {
     this.remove();
   };
@@ -104,13 +112,13 @@ if (initialFallbackData) {
 //   }
 // }
 function sendMessageToReact(objectData, isPopupOpen = false) {
-  if (!objectData) {
+  if (!objectData || !extensionApi?.runtime?.sendMessage) {
     return;
   }
 
-  chrome.runtime.sendMessage(chrome.runtime.id, objectData, () => {
-    if (chrome.runtime.lastError) {
-      const errorMessage = chrome.runtime.lastError.message || '';
+  extensionApi.runtime.sendMessage(objectData, () => {
+    if (extensionApi.runtime.lastError) {
+      const errorMessage = extensionApi.runtime.lastError.message || '';
       if (errorMessage.includes(MESSAGE_PORT_CLOSED_ERROR)) {
         return;
       }
@@ -138,25 +146,27 @@ window.addEventListener(
   false
 );
 
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.popupIsOpen) {
-    if (!data) {
-      const fallbackData = getFallbackThemeData();
-      if (fallbackData) {
-        data = fallbackData;
-        sendResponse(fallbackData);
-        sendMessageToReact(fallbackData, true);
+if (extensionApi?.runtime?.onMessage?.addListener) {
+  extensionApi.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.popupIsOpen) {
+      if (!data) {
+        const fallbackData = getFallbackThemeData();
+        if (fallbackData) {
+          data = fallbackData;
+          sendResponse(fallbackData);
+          sendMessageToReact(fallbackData, true);
+          return;
+        }
+
+        appendInjectScript('src/pages/Inject/index.js', (event) => {
+          console.error('Error reloading script for popup request:', event);
+        });
+        sendResponse(null);
         return;
       }
 
-      appendInjectScript('src/pages/Inject/index.js', (event) => {
-        console.error('Error reloading script for popup request:', event);
-      });
-      sendResponse(null);
-      return;
+      sendResponse(data);
+      sendMessageToReact(data, true);
     }
-
-    sendResponse(data);
-    sendMessageToReact(data, true);
-  }
-});
+  });
+}

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -1,8 +1,12 @@
 import getExtensionApi from '../../utils/getExtensionApi';
 
 let data = null;
+let injectScriptIsLoading = false;
+let lastInjectAttemptAt = 0;
 const MESSAGE_PORT_CLOSED_ERROR =
   'The message port closed before a response was received.';
+const INJECT_RETRY_INTERVAL_MS = 1000;
+const INJECT_SCRIPT_MARKER_ATTRIBUTE = 'data-theme-explorer-inject';
 
 const extensionApi = getExtensionApi();
 
@@ -81,13 +85,35 @@ function appendInjectScript(srcPath, onError) {
     return;
   }
 
+  const now = Date.now();
+  if (
+    injectScriptIsLoading ||
+    now - lastInjectAttemptAt < INJECT_RETRY_INTERVAL_MS
+  ) {
+    return;
+  }
+
+  const scriptUrl = extensionApi.runtime.getURL(srcPath);
+  const existingInjectScript = document.querySelector(
+    `script[${INJECT_SCRIPT_MARKER_ATTRIBUTE}="true"][src="${scriptUrl}"]`
+  );
+  if (existingInjectScript) {
+    return;
+  }
+
+  injectScriptIsLoading = true;
+  lastInjectAttemptAt = now;
+
   const script = document.createElement('script');
-  script.src = extensionApi.runtime.getURL(srcPath);
+  script.src = scriptUrl;
+  script.setAttribute(INJECT_SCRIPT_MARKER_ATTRIBUTE, 'true');
   script.onload = function () {
+    injectScriptIsLoading = false;
     this.remove();
   };
 
   script.onerror = function (event) {
+    injectScriptIsLoading = false;
     this.remove();
     if (onError) onError(event);
   };

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -355,50 +355,48 @@ const Popup = () => {
       };
 
       const sendPopupOpenMessage = () => {
-        extensionApi.tabs.sendMessage(
-          state.currentTab.id,
-          { popupIsOpen: true },
-          (response) => {
+        extensionApi.tabs
+          .sendMessage(state.currentTab.id, { popupIsOpen: true })
+          .then((response) => {
             if (response && response.type === 'theme' && response.data) {
               registerOnMessage(response);
+            }
+          })
+          .catch((error) => {
+            const errorMessage =
+              error?.message || extensionApi?.runtime?.lastError?.message || '';
+
+            if (
+              errorMessage.includes(MESSAGE_PORT_CLOSED_ERROR) ||
+              errorMessage.includes(RECEIVING_END_MISSING_ERROR)
+            ) {
+              if (errorMessage.includes(RECEIVING_END_MISSING_ERROR)) {
+                ensureContentScriptInjected(state.currentTab.id);
+
+                if (!attemptedMainWorldFallbackRef.current) {
+                  attemptedMainWorldFallbackRef.current = true;
+                  fetchStorefrontDataFromMainWorld(state.currentTab.id).then(
+                    (mainWorldData) => {
+                      if (mainWorldData) {
+                        registerOnMessage(mainWorldData);
+                      }
+                    }
+                  );
+                }
+              }
               return;
             }
 
-            if (extensionApi.runtime.lastError) {
-              const errorMessage = extensionApi.runtime.lastError.message || '';
-              if (
-                errorMessage.includes(MESSAGE_PORT_CLOSED_ERROR) ||
-                errorMessage.includes(RECEIVING_END_MISSING_ERROR)
-              ) {
-                if (errorMessage.includes(RECEIVING_END_MISSING_ERROR)) {
-                  ensureContentScriptInjected(state.currentTab.id);
-
-                  if (!attemptedMainWorldFallbackRef.current) {
-                    attemptedMainWorldFallbackRef.current = true;
-                    fetchStorefrontDataFromMainWorld(state.currentTab.id).then(
-                      (mainWorldData) => {
-                        if (mainWorldData) {
-                          registerOnMessage(mainWorldData);
-                        }
-                      }
-                    );
-                  }
-                }
-                return;
-              }
-
-              console.debug(
-                'Theme Explorer: popup message not delivered:',
-                errorMessage
-              );
-              stopPolling();
-              setLoadError(
-                'Unable to communicate with the page',
-                'Theme Explorer could not read storefront data from this tab. Reload the page and retry.'
-              );
-            }
-          }
-        );
+            console.debug(
+              'Theme Explorer: popup message not delivered:',
+              errorMessage
+            );
+            stopPolling();
+            setLoadError(
+              'Unable to communicate with the page',
+              'Theme Explorer could not read storefront data from this tab. Reload the page and retry.'
+            );
+          });
       };
 
       const timeoutId = window.setTimeout(() => {

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -8,6 +8,9 @@ import LoadingComponent from '../../containers/LoadingComponent/LoadingComponent
 import AdminComponent from '../../containers/AdminComponent/AdminComponent';
 import StorefrontComponent from '../../containers/StorefrontComponent/StorefrontComponent';
 import NotFound from '../../containers/NotFound/NotFound';
+import getExtensionApi from '../../utils/getExtensionApi';
+
+const extensionApi = getExtensionApi();
 
 const Popup = () => {
   const MESSAGE_PORT_CLOSED_ERROR =
@@ -49,12 +52,12 @@ const Popup = () => {
   }, []);
 
   const fetchStorefrontDataFromMainWorld = useCallback(async (tabId) => {
-    if (!tabId || !chrome.scripting?.executeScript) {
+    if (!tabId || !extensionApi?.scripting?.executeScript) {
       return null;
     }
 
     try {
-      const results = await chrome.scripting.executeScript({
+      const results = await extensionApi.scripting.executeScript({
         target: { tabId },
         world: 'MAIN',
         func: () => {
@@ -97,7 +100,7 @@ const Popup = () => {
   }, []);
 
   const ensureContentScriptInjected = useCallback(async (tabId) => {
-    if (!tabId || !chrome.scripting?.executeScript) {
+    if (!tabId || !extensionApi?.scripting?.executeScript) {
       return false;
     }
 
@@ -108,7 +111,7 @@ const Popup = () => {
     attemptedContentInjectionRef.current = true;
 
     try {
-      await chrome.scripting.executeScript({
+      await extensionApi.scripting.executeScript({
         target: { tabId },
         files: ['src/pages/Content/index.js'],
       });
@@ -157,9 +160,17 @@ const Popup = () => {
   };
 
   const getCurrentTab = async () => {
+    if (!extensionApi?.tabs?.query) {
+      setLoadError(
+        'Browser API unavailable',
+        'Theme Explorer could not access extension tab APIs in this browser.'
+      );
+      return;
+    }
+
     try {
       const queryOptions = { active: true, currentWindow: true };
-      const [tab] = await chrome.tabs.query(queryOptions);
+      const [tab] = await extensionApi.tabs.query(queryOptions);
 
       setState((prevState) => ({
         ...prevState,
@@ -326,6 +337,10 @@ const Popup = () => {
   // }, []); // Adjust dependencies based on your needs
 
   useEffect(() => {
+    if (!extensionApi?.tabs?.sendMessage || !extensionApi?.runtime?.onMessage) {
+      return undefined;
+    }
+
     const handleMessage = (request) => {
       registerOnMessage(request);
     };
@@ -340,7 +355,7 @@ const Popup = () => {
       };
 
       const sendPopupOpenMessage = () => {
-        chrome.tabs.sendMessage(
+        extensionApi.tabs.sendMessage(
           state.currentTab.id,
           { popupIsOpen: true },
           (response) => {
@@ -349,8 +364,8 @@ const Popup = () => {
               return;
             }
 
-            if (chrome.runtime.lastError) {
-              const errorMessage = chrome.runtime.lastError.message || '';
+            if (extensionApi.runtime.lastError) {
+              const errorMessage = extensionApi.runtime.lastError.message || '';
               if (
                 errorMessage.includes(MESSAGE_PORT_CLOSED_ERROR) ||
                 errorMessage.includes(RECEIVING_END_MISSING_ERROR)
@@ -405,13 +420,13 @@ const Popup = () => {
         sendPopupOpenMessage();
       }, STOREFRONT_MESSAGE_RETRY_INTERVAL_MS);
 
-      chrome.runtime.onMessage.addListener(handleMessage);
+      extensionApi.runtime.onMessage.addListener(handleMessage);
       sendPopupOpenMessage();
 
       return () => {
         window.clearTimeout(timeoutId);
         stopPolling();
-        chrome.runtime.onMessage.removeListener(handleMessage);
+        extensionApi.runtime.onMessage.removeListener(handleMessage);
       };
     }
   }, [

--- a/src/utils/getExtensionApi.js
+++ b/src/utils/getExtensionApi.js
@@ -1,0 +1,22 @@
+const getRuntimeRoot = () => {
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+
+  if (typeof browser !== 'undefined') {
+    return { browser };
+  }
+
+  if (typeof chrome !== 'undefined') {
+    return { chrome };
+  }
+
+  return {};
+};
+
+const getExtensionApi = () => {
+  const runtimeRoot = getRuntimeRoot();
+  return runtimeRoot.browser || runtimeRoot.chrome || null;
+};
+
+export default getExtensionApi;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { crx } from '@crxjs/vite-plugin';
@@ -32,8 +33,36 @@ export default defineConfig(({ mode }) => {
     };
   }
 
+  const firefoxManifestCompatibilityPlugin = {
+    name: 'firefox-manifest-compatibility',
+    closeBundle() {
+      if (targetBrowser !== 'firefox') {
+        return;
+      }
+
+      const manifestPath = path.resolve('build-vite/manifest.json');
+      if (!fs.existsSync(manifestPath)) {
+        return;
+      }
+
+      const buildManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      const resources = buildManifest.web_accessible_resources || [];
+
+      buildManifest.web_accessible_resources = resources.map((entry) => {
+        if (!entry || typeof entry !== 'object') {
+          return entry;
+        }
+
+        const { use_dynamic_url, ...rest } = entry;
+        return rest;
+      });
+
+      fs.writeFileSync(manifestPath, JSON.stringify(buildManifest, null, 2));
+    },
+  };
+
   return {
-    plugins: [react(), crx({ manifest })],
+    plugins: [react(), crx({ manifest }), firefoxManifestCompatibilityPlugin],
     server: {
       host: true,
       port: 5173,


### PR DESCRIPTION
## Summary
- Fix Firefox temporary add-on installation errors by emitting background scripts for Firefox builds.
- Keep background code classic-script compatible in Firefox while retaining cross-browser API guards.
- Add a shared extension API helper for popup and content contexts.
- Strip unsupported use_dynamic_url from Firefox manifests after build.
- Add cross-browser parity QA notes and update the release QA checklist.
- Update build verification to accept either MV3 service worker (Chrome) or background scripts (Firefox).

## Verification
- npm run build:prod
- npm run build:firefox
- npm run qa:verify-build
- npm run package:bundle:firefox