### PR TITLE
THE-11: define and enforce popup/script performance budgets

### DIFF
--- a/.github/workflows/qa-release-candidate.yml
+++ b/.github/workflows/qa-release-candidate.yml
@@ -22,7 +22,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Set up Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
       - name: Run QA release candidate checks
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: npm run qa:release-candidate
 
       - name: Capture release candidate metadata

--- a/config/performance-budget.json
+++ b/config/performance-budget.json
@@ -1,0 +1,34 @@
+{
+  "popupFirstRenderMs": {
+    "budget": 300,
+    "baseline": 20
+  },
+  "popupJsBytes": {
+    "budget": 260000,
+    "baseline": 221709
+  },
+  "popupCssBytes": {
+    "budget": 28000,
+    "baseline": 23065
+  },
+  "popupAssetBytes": {
+    "budget": 330000,
+    "baseline": 294874
+  },
+  "popupFootprintBytes": {
+    "budget": 610000,
+    "baseline": 539648
+  },
+  "contentScriptBytes": {
+    "budget": 5000,
+    "baseline": 2110
+  },
+  "injectScriptBytes": {
+    "budget": 3500,
+    "baseline": 2140
+  },
+  "backgroundScriptBytes": {
+    "budget": 2000,
+    "baseline": 470
+  }
+}

--- a/docs/qa/performance-budget.md
+++ b/docs/qa/performance-budget.md
@@ -1,0 +1,51 @@
+# Performance Budget
+
+This document defines the performance budgets for Theme Explorer V2 and how we enforce them before release.
+
+## Scope
+
+We currently gate:
+
+- Popup bundle footprint (JavaScript, CSS, and bundled popup assets)
+- Content script, inject script, and background script size
+- Popup first meaningful render time (instrumented in popup runtime)
+
+## Budget thresholds
+
+Source of truth: `config/performance-budget.json`
+
+Current thresholds:
+
+- `popupFirstRenderMs`: `300ms` (baseline `20ms`)
+- `popupJsBytes`: `260000` bytes (baseline `221709`)
+- `popupCssBytes`: `28000` bytes (baseline `23065`)
+- `popupAssetBytes`: `330000` bytes (baseline `294874`)
+- `popupFootprintBytes`: `610000` bytes (baseline `539648`)
+- `contentScriptBytes`: `5000` bytes (baseline `2110`)
+- `injectScriptBytes`: `3500` bytes (baseline `2140`)
+- `backgroundScriptBytes`: `2000` bytes (baseline `470`)
+
+## How budgets are checked
+
+1. Build the production extension:
+   - `npm run build:prod`
+2. Run build verification and performance checks:
+   - `npm run qa:verify-build`
+
+`npm run qa:verify-build` includes `npm run qa:performance`, which runs:
+
+- `scripts/qa/check-performance-budget.js` for bundle/script size budgets
+- `scripts/qa/check-popup-render-time.js` for `popupFirstRenderMs`
+
+If any metric exceeds its budget, the script exits with code `1` so regressions are caught before release.
+
+`check-popup-render-time.js` requires a local Chrome executable. If needed, set `CHROME_PATH` explicitly.
+
+## Updating baselines
+
+When intentional performance changes land:
+
+1. Rebuild with `npm run build:prod`.
+2. Run `npm run qa:performance` and capture the measured values.
+3. Update the `baseline` values in `config/performance-budget.json`.
+4. Only increase `budget` when there is a justified product or technical reason.

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -5,11 +5,13 @@ Run this checklist for every release candidate.
 Reference runbooks:
 - `docs/qa/release-pipeline.md`
 - `docs/qa/rollback-plan.md`
+- `docs/qa/performance-budget.md`
 
 ## 1. Build and artefact verification
 
 - [ ] `npm ci` completed without errors
 - [ ] `npm run qa:release-candidate` passed
+- [ ] `npm run qa:performance` passed and no budget threshold was exceeded
 - [ ] `build-vite/manifest.json` version matches `package.json`
 - [ ] Extension loads successfully in Chrome and Firefox
 

--- a/docs/qa/release-pipeline.md
+++ b/docs/qa/release-pipeline.md
@@ -23,7 +23,8 @@ Produce a repeatable release artefact, validate it, and capture sign-off evidenc
 
 1. Run `npm ci`.
 2. Run `npm run qa:release-candidate`.
-3. Verify local output in `build-vite/`.
+3. Review `docs/qa/performance-budget.md` and confirm no budget overruns.
+4. Verify local output in `build-vite/`.
 
 ## 3. CI candidate artefact
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "package:bundle:firefox": "node scripts/package-bundles.js firefox",
     "package:bundle": "node scripts/package-bundles.js",
     "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
-    "qa:verify-build": "node scripts/qa/verify-build.js",
+    "qa:verify-build": "node scripts/qa/verify-build.js && npm run qa:performance",
+    "qa:performance": "node scripts/qa/check-performance-budget.js && node scripts/qa/check-popup-render-time.js",
     "qa:release-candidate": "npm run build:prod && npm run qa:verify-build"
   },
   "dependencies": {

--- a/scripts/qa/check-performance-budget.js
+++ b/scripts/qa/check-performance-budget.js
@@ -1,0 +1,241 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..', '..');
+const buildDir = path.join(rootDir, 'build-vite');
+const viteManifestPath = path.join(buildDir, '.vite', 'manifest.json');
+const extensionManifestPath = path.join(buildDir, 'manifest.json');
+const budgetPath = path.join(rootDir, 'config', 'performance-budget.json');
+const KB_DIVISOR = 1024;
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const CYAN = '\x1b[36m';
+const YELLOW = '\x1b[33m';
+
+function formatBytes(bytes) {
+  return `${(bytes / KB_DIVISOR).toFixed(2)} KB`;
+}
+
+function supportsColor() {
+  return Boolean(process.stdout && process.stdout.isTTY && process.env.TERM !== 'dumb');
+}
+
+function colour(text, colourCode) {
+  if (!supportsColor()) {
+    return text;
+  }
+
+  return `${colourCode}${text}${RESET}`;
+}
+
+function emphasise(text) {
+  if (!supportsColor()) {
+    return text;
+  }
+
+  return `${BOLD}${text}${RESET}`;
+}
+
+function dim(text) {
+  if (!supportsColor()) {
+    return text;
+  }
+
+  return `${DIM}${text}${RESET}`;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function ensureFile(filePath, message) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(message);
+  }
+}
+
+function getFileSize(relativePath) {
+  const filePath = path.join(buildDir, relativePath);
+  ensureFile(filePath, `Missing emitted file: ${relativePath}`);
+  return fs.statSync(filePath).size;
+}
+
+function collectEntryAndImports(viteManifest, entryKey, visited = new Set()) {
+  if (!entryKey || visited.has(entryKey)) {
+    return visited;
+  }
+
+  const entry = viteManifest[entryKey];
+  if (!entry) {
+    return visited;
+  }
+
+  visited.add(entryKey);
+
+  (entry.imports || []).forEach((importKey) => {
+    collectEntryAndImports(viteManifest, importKey, visited);
+  });
+
+  return visited;
+}
+
+function getEntryBundleSize(viteManifest, entryKey) {
+  const entries = Array.from(collectEntryAndImports(viteManifest, entryKey));
+  return entries.reduce((total, key) => {
+    const file = viteManifest[key] && viteManifest[key].file;
+    if (!file) {
+      return total;
+    }
+
+    return total + getFileSize(file);
+  }, 0);
+}
+
+function metric(name, value, budgets) {
+  const metricBudget = budgets[name];
+  if (!metricBudget) {
+    throw new Error(`Missing budget for metric: ${name}`);
+  }
+
+  return {
+    name,
+    value,
+    budget: metricBudget.budget,
+    baseline: metricBudget.baseline,
+    ok: value <= metricBudget.budget,
+  };
+}
+
+function getPopupMetrics(viteManifest) {
+  const popupKey = 'src/pages/Popup/index.html';
+  const popupEntry = viteManifest[popupKey];
+  if (!popupEntry || !popupEntry.file) {
+    throw new Error('Popup entry was not found in .vite manifest');
+  }
+
+  const popupJsBytes = getEntryBundleSize(viteManifest, popupKey);
+
+  const popupCssBytes = (popupEntry.css || []).reduce((total, cssFile) => {
+    return total + getFileSize(cssFile);
+  }, 0);
+
+  const popupAssetBytes = (popupEntry.assets || []).reduce((total, assetFile) => {
+    return total + getFileSize(assetFile);
+  }, 0);
+
+  return {
+    popupJsBytes,
+    popupCssBytes,
+    popupAssetBytes,
+    popupFootprintBytes: popupJsBytes + popupCssBytes + popupAssetBytes,
+  };
+}
+
+function getScriptMetrics(viteManifest, extensionManifest) {
+  const contentKey = 'src/pages/Content/index.js';
+  const backgroundKey = 'src/pages/Background/index.js';
+  const injectPath = 'src/pages/Inject/index.js';
+
+  const contentScriptBytes = getEntryBundleSize(viteManifest, contentKey);
+  const backgroundScriptBytes = getEntryBundleSize(viteManifest, backgroundKey);
+  const injectScriptBytes = getFileSize(injectPath);
+
+  if (!extensionManifest?.content_scripts?.[0]?.js?.[0]) {
+    throw new Error('No emitted content script path found in extension manifest');
+  }
+
+  return {
+    contentScriptBytes,
+    injectScriptBytes,
+    backgroundScriptBytes,
+  };
+}
+
+function printReport(results) {
+  const heading = emphasise(colour('Performance Budget Report', CYAN));
+  const divider = dim('-'.repeat(105));
+  console.log(`\n${heading}`);
+  console.log(divider);
+  console.log(
+    `${dim('STATUS'.padEnd(8, ' '))}${dim('METRIC'.padEnd(24, ' '))}${dim(
+      'CURRENT'.padStart(13, ' ')
+    )}${dim('BASELINE'.padStart(13, ' '))}${dim('BUDGET'.padStart(13, ' '))}${dim(
+      'DELTA'.padStart(13, ' ')
+    )}`
+  );
+  console.log(divider);
+
+  results.forEach((result) => {
+    const status = result.ok
+      ? colour('PASS', GREEN)
+      : colour('FAIL', RED);
+    const delta = result.value - result.baseline;
+    const deltaLabel = `${delta >= 0 ? '+' : ''}${formatBytes(delta)}`;
+    const deltaColour = delta > 0 ? YELLOW : GREEN;
+    const line = [
+      status.padEnd(8, ' '),
+      result.name.padEnd(24, ' '),
+      `${formatBytes(result.value).padStart(13, ' ')}`,
+      `${formatBytes(result.baseline).padStart(13, ' ')}`,
+      `${formatBytes(result.budget).padStart(13, ' ')}`,
+      `${colour(deltaLabel.padStart(13, ' '), deltaColour)}`,
+    ].join('  ');
+    console.log(line);
+  });
+  console.log(divider);
+}
+
+function run() {
+  try {
+    ensureFile(
+      viteManifestPath,
+      'No build manifest found at build-vite/.vite/manifest.json. Run `npm run build:prod` first.'
+    );
+    ensureFile(
+      extensionManifestPath,
+      'No extension manifest found at build-vite/manifest.json. Run `npm run build:prod` first.'
+    );
+    ensureFile(
+      budgetPath,
+      'No performance budget config found at config/performance-budget.json.'
+    );
+
+    const budgets = readJson(budgetPath);
+    const viteManifest = readJson(viteManifestPath);
+    const extensionManifest = readJson(extensionManifestPath);
+
+    const popupMetrics = getPopupMetrics(viteManifest);
+    const scriptMetrics = getScriptMetrics(viteManifest, extensionManifest);
+
+    const results = [
+      metric('popupJsBytes', popupMetrics.popupJsBytes, budgets),
+      metric('popupCssBytes', popupMetrics.popupCssBytes, budgets),
+      metric('popupAssetBytes', popupMetrics.popupAssetBytes, budgets),
+      metric('popupFootprintBytes', popupMetrics.popupFootprintBytes, budgets),
+      metric('contentScriptBytes', scriptMetrics.contentScriptBytes, budgets),
+      metric('injectScriptBytes', scriptMetrics.injectScriptBytes, budgets),
+      metric('backgroundScriptBytes', scriptMetrics.backgroundScriptBytes, budgets),
+    ];
+
+    printReport(results);
+
+    const failed = results.filter((result) => !result.ok);
+    if (failed.length > 0) {
+      process.exitCode = 1;
+      console.error(
+        `\n${colour('Performance budget check failed', RED)} for ${failed.length} metric(s).`
+      );
+      return;
+    }
+
+    console.log(`\n${colour('Performance budget check passed.', GREEN)}`);
+  } catch (error) {
+    process.exitCode = 1;
+    console.error(`\n${colour('Performance budget check failed:', RED)} ${error.message}`);
+  }
+}
+
+run();

--- a/scripts/qa/check-popup-render-time.js
+++ b/scripts/qa/check-popup-render-time.js
@@ -1,0 +1,251 @@
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const os = require('node:os');
+const { execFile } = require('node:child_process');
+
+const rootDir = path.resolve(__dirname, '..', '..');
+const buildDir = path.join(rootDir, 'build-vite');
+const budgetPath = path.join(rootDir, 'config', 'performance-budget.json');
+const popupEntryPath = path.join(buildDir, 'src', 'pages', 'Popup', 'index.html');
+const METRIC_ATTRIBUTE = 'data-theme-explorer-popup-first-render-ms';
+const TABLE_WIDTH = 89;
+const STATUS_WIDTH = 8;
+const METRIC_WIDTH = 24;
+const VALUE_WIDTH = 13;
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const CYAN = '\x1b[36m';
+const YELLOW = '\x1b[33m';
+
+function supportsColor() {
+  return Boolean(process.stdout && process.stdout.isTTY && process.env.TERM !== 'dumb');
+}
+
+function colour(text, colourCode) {
+  if (!supportsColor()) {
+    return text;
+  }
+
+  return `${colourCode}${text}${RESET}`;
+}
+
+function emphasise(text) {
+  if (!supportsColor()) {
+    return text;
+  }
+
+  return `${BOLD}${text}${RESET}`;
+}
+
+function dim(text) {
+  if (!supportsColor()) {
+    return text;
+  }
+
+  return `${DIM}${text}${RESET}`;
+}
+
+function ensureFile(filePath, message) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(message);
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function resolveChromePath() {
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+  ].filter(Boolean);
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
+}
+
+function startStaticServer(root) {
+  const server = http.createServer((request, response) => {
+    const requestPath = decodeURIComponent((request.url || '/').split('?')[0]);
+    const safePath = path
+      .normalize(requestPath)
+      .replace(/^(\.\.[/\\])+/, '')
+      .replace(/^[/\\]+/, '');
+    const filePath = path.join(root, safePath || 'index.html');
+
+    if (!filePath.startsWith(root)) {
+      response.statusCode = 403;
+      response.end('Forbidden');
+      return;
+    }
+
+    fs.readFile(filePath, (error, data) => {
+      if (error) {
+        response.statusCode = 404;
+        response.end('Not found');
+        return;
+      }
+
+      if (filePath.endsWith('.html')) response.setHeader('Content-Type', 'text/html');
+      if (filePath.endsWith('.js')) response.setHeader('Content-Type', 'application/javascript');
+      if (filePath.endsWith('.css')) response.setHeader('Content-Type', 'text/css');
+      if (filePath.endsWith('.svg')) response.setHeader('Content-Type', 'image/svg+xml');
+      if (filePath.endsWith('.woff2')) response.setHeader('Content-Type', 'font/woff2');
+      response.end(data);
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+function execFileAsync(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, options, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${error.message}\n${stderr || ''}`.trim()));
+        return;
+      }
+
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function extractMetricValue(domText) {
+  const regex = new RegExp(`${METRIC_ATTRIBUTE}="(\\d+)"`);
+  const match = domText.match(regex);
+  return match ? Number(match[1]) : null;
+}
+
+async function run() {
+  const heading = emphasise(colour('Popup Render Budget Check', CYAN));
+  console.log(`\n${heading}`);
+  console.log(dim('-'.repeat(TABLE_WIDTH)));
+
+  ensureFile(
+    popupEntryPath,
+    'Popup build output not found. Run `npm run build:prod` first.'
+  );
+  ensureFile(
+    budgetPath,
+    'No performance budget config found at config/performance-budget.json.'
+  );
+
+  const budgetConfig = readJson(budgetPath);
+  const popupBudgetMetric = budgetConfig.popupFirstRenderMs;
+  if (!popupBudgetMetric) {
+    throw new Error('Missing popupFirstRenderMs metric in performance budget config.');
+  }
+
+  const chromePath = resolveChromePath();
+  if (!chromePath) {
+    throw new Error(
+      'Google Chrome was not found. Set CHROME_PATH to a Chrome executable to run popup render checks.'
+    );
+  }
+
+  const { server, port } = await startStaticServer(buildDir);
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'theme-explorer-chrome-'));
+  const popupUrl = `http://127.0.0.1:${port}/src/pages/Popup/index.html`;
+
+  try {
+    console.log(dim('Launching headless Chrome to sample popup render time...'));
+
+    const chromeArgs = [
+      '--headless=new',
+      '--disable-gpu',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--allow-file-access-from-files',
+      `--user-data-dir=${userDataDir}`,
+      '--virtual-time-budget=6000',
+      '--dump-dom',
+      popupUrl,
+    ];
+
+    const { stdout } = await execFileAsync(chromePath, chromeArgs, {
+      timeout: 20000,
+      maxBuffer: 1024 * 1024 * 5,
+    });
+    console.log(dim('Headless Chrome completed. Parsing render metric...'));
+
+    const measuredMs = extractMetricValue(stdout);
+    if (measuredMs == null) {
+      throw new Error(
+        `Could not find ${METRIC_ATTRIBUTE} in popup DOM output.`
+      );
+    }
+
+    const budgetMs = popupBudgetMetric.budget;
+    const baselineMs = popupBudgetMetric.baseline;
+    const deltaMs = measuredMs - baselineMs;
+    const statusText = measuredMs <= budgetMs ? 'PASS' : 'FAIL';
+    const status = colour(statusText.padEnd(8, ' '), measuredMs <= budgetMs ? GREEN : RED);
+    const deltaLabel = `${deltaMs >= 0 ? '+' : ''}${deltaMs}ms`;
+    const deltaColour = deltaMs > 0 ? YELLOW : GREEN;
+
+    console.log(
+      [
+        dim('STATUS'.padEnd(STATUS_WIDTH, ' ')),
+        dim('METRIC'.padEnd(METRIC_WIDTH, ' ')),
+        dim('CURRENT'.padStart(VALUE_WIDTH, ' ')),
+        dim('BASELINE'.padStart(VALUE_WIDTH, ' ')),
+        dim('BUDGET'.padStart(VALUE_WIDTH, ' ')),
+        dim('DELTA'.padStart(VALUE_WIDTH, ' ')),
+      ].join('  ')
+    );
+    console.log(dim('-'.repeat(TABLE_WIDTH)));
+    console.log(
+      [
+        status.padEnd(STATUS_WIDTH, ' '),
+        'popupFirstRenderMs'.padEnd(METRIC_WIDTH, ' '),
+        `${measuredMs}ms`.padStart(VALUE_WIDTH, ' '),
+        `${baselineMs}ms`.padStart(VALUE_WIDTH, ' '),
+        `${budgetMs}ms`.padStart(VALUE_WIDTH, ' '),
+        colour(deltaLabel.padStart(VALUE_WIDTH, ' '), deltaColour),
+      ].join('  ')
+    );
+    console.log(dim('-'.repeat(TABLE_WIDTH)));
+
+    if (measuredMs > budgetMs) {
+      process.exitCode = 1;
+      console.error(
+        `\n${colour(
+          'Popup render budget check failed.',
+          RED
+        )} Measured ${measuredMs}ms exceeds budget ${budgetMs}ms.`
+      );
+      return;
+    }
+
+    console.log(`\n${colour('Popup render budget check passed.', GREEN)}`);
+  } finally {
+    server.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+}
+
+run().catch((error) => {
+  process.exitCode = 1;
+  const message = error.message.includes('timed out')
+    ? `${error.message}\n${dim(
+        'Tip: set CHROME_PATH to a local Chrome binary or rerun if Chrome was starting for the first time.'
+      )}`
+    : error.message;
+  console.error(`\n${colour('Popup render budget check failed:', RED)} ${message}`);
+});

--- a/scripts/qa/check-popup-render-time.js
+++ b/scripts/qa/check-popup-render-time.js
@@ -73,6 +73,16 @@ function resolveChromePath() {
   return candidates.find((candidate) => fs.existsSync(candidate)) || null;
 }
 
+function getChromeSandboxArgs() {
+  // GitHub-hosted Linux runners often cannot use the bundled setuid sandbox.
+  // In CI we explicitly disable it so headless checks remain deterministic.
+  if (process.platform === 'linux') {
+    return ['--no-sandbox', '--disable-setuid-sandbox'];
+  }
+
+  return [];
+}
+
 function startStaticServer(root) {
   const server = http.createServer((request, response) => {
     const requestPath = decodeURIComponent((request.url || '/').split('?')[0]);
@@ -172,6 +182,7 @@ async function run() {
       '--no-first-run',
       '--no-default-browser-check',
       '--allow-file-access-from-files',
+      ...getChromeSandboxArgs(),
       `--user-data-dir=${userDataDir}`,
       '--virtual-time-budget=6000',
       '--dump-dom',

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -19,6 +19,7 @@ const Popup = () => {
     'Could not establish connection. Receiving end does not exist.';
   const STOREFRONT_TIMEOUT_MS = 1000;
   const STOREFRONT_MESSAGE_RETRY_INTERVAL_MS = 300;
+  const POPUP_FIRST_RENDER_BUDGET_MS = 300;
 
   const [state, setState] = useState({
     themes: null,
@@ -39,6 +40,10 @@ const Popup = () => {
   });
   const attemptedContentInjectionRef = useRef(false);
   const attemptedMainWorldFallbackRef = useRef(false);
+  const popupMountStartRef = useRef(
+    typeof performance !== 'undefined' ? performance.now() : Date.now()
+  );
+  const hasReportedFirstRenderRef = useRef(false);
 
   const setLoadError = useCallback((title, message) => {
     setState((prevState) => ({
@@ -439,6 +444,46 @@ const Popup = () => {
   const handleRetry = () => {
     window.location.reload();
   };
+
+  const hasTerminalView =
+    !!state.storefrontInformation ||
+    state.loadError ||
+    (state.adminShown &&
+      state.themesReady &&
+      !state.storeUrl &&
+      !state.storefrontInformation) ||
+    (state.adminShown &&
+      state.themesReady &&
+      state.shop &&
+      !state.storefrontInformation) ||
+    (state.currentTabResolved &&
+      !state.adminShown &&
+      state.storefrontCheckComplete);
+
+  useEffect(() => {
+    if (!hasTerminalView || hasReportedFirstRenderRef.current) {
+      return;
+    }
+
+    hasReportedFirstRenderRef.current = true;
+    const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const durationMs = Math.round(end - popupMountStartRef.current);
+
+    window.__THEME_EXPLORER_PERF__ = {
+      ...(window.__THEME_EXPLORER_PERF__ || {}),
+      popupFirstRenderMs: durationMs,
+    };
+    document.documentElement.setAttribute(
+      'data-theme-explorer-popup-first-render-ms',
+      String(durationMs)
+    );
+
+    if (durationMs > POPUP_FIRST_RENDER_BUDGET_MS) {
+      console.warn(
+        `Theme Explorer popup first render exceeded budget: ${durationMs}ms > ${POPUP_FIRST_RENDER_BUDGET_MS}ms`
+      );
+    }
+  }, [hasTerminalView, POPUP_FIRST_RENDER_BUDGET_MS]);
 
   // if (!state.storefrontInformation && state.currentTab && !state.adminShown) {
   //   chrome.runtime.onMessage.addListener((request) =>


### PR DESCRIPTION
## Summary
This PR completes THE-11 by adding enforceable performance budgets for extension footprint and popup load timing, and by wiring those checks into release QA.

## New checks
### 1) Static footprint budget check
Script: `scripts/qa/check-performance-budget.js`

What it validates from the production build (`build-vite`):
- `popupJsBytes`
- `popupCssBytes`
- `popupAssetBytes`
- `popupFootprintBytes`
- `contentScriptBytes`
- `injectScriptBytes`
- `backgroundScriptBytes`

Behaviour:
- Reads thresholds + baselines from `config/performance-budget.json`
- Prints a formatted report with current/baseline/budget/delta
- Fails with non-zero exit code if any metric exceeds budget

### 2) Popup render-time budget check
Script: `scripts/qa/check-popup-render-time.js`

How it works:
- Serves `build-vite` locally
- Launches headless Chrome
- Loads `src/pages/Popup/index.html`
- Reads `data-theme-explorer-popup-first-render-ms` from the rendered DOM

Behaviour:
- Compares measured `popupFirstRenderMs` against budget in `config/performance-budget.json`
- Outputs PASS/FAIL with delta from baseline
- Fails with non-zero exit code on budget breach

## Runtime instrumentation
- `src/pages/Popup/Popup.jsx` now records first terminal render duration and exposes it as:
  - `window.__THEME_EXPLORER_PERF__.popupFirstRenderMs`
  - `data-theme-explorer-popup-first-render-ms` on `<html>`

## QA / CI integration
- `package.json`
  - `qa:performance` now runs both checks:
    - `check-performance-budget.js`
    - `check-popup-render-time.js`
  - `qa:verify-build` invokes `qa:performance`
- `.github/workflows/qa-release-candidate.yml`
  - Adds Chrome setup (`browser-actions/setup-chrome@v1`)
  - Passes `CHROME_PATH` into QA step for deterministic CI execution

## Documentation updates
- Added `docs/qa/performance-budget.md`
- Updated:
  - `docs/qa/release-checklist.md`
  - `docs/qa/release-pipeline.md`

## Validation performed
- `npm run build:prod`
- `npm run qa:performance`
- `npm run qa:verify-build`

All checks passed locally on commit `b734255`.
